### PR TITLE
add to headers

### DIFF
--- a/pkg/pagination/pagination.go
+++ b/pkg/pagination/pagination.go
@@ -95,7 +95,9 @@ func (p *paginator) validatePageSize(size int) error {
 
 func (p *paginator) setPageAndPageSize(page int, size int) {
 	p.c.Set(p.opts.PageText, page)
+	p.c.Header(p.opts.PageText, strconv.Itoa(page))
 	p.c.Set(p.opts.SizeText, size)
+	p.c.Header(p.opts.SizeText, strconv.Itoa(size))
 }
 
 func (p *paginator) Next() {

--- a/pkg/pagination/pagination.go
+++ b/pkg/pagination/pagination.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"net/http"
 	"strconv"
+	"strings"
 
 	"github.com/gin-gonic/gin"
 )
@@ -95,11 +96,20 @@ func (p *paginator) validatePageSize(size int) error {
 
 func (p *paginator) setPageAndPageSize(page int, size int) {
 	p.c.Set(p.opts.PageText, page)
-	p.c.Header(p.opts.PageText, strconv.Itoa(page))
 	p.c.Set(p.opts.SizeText, size)
-	p.c.Header(p.opts.SizeText, strconv.Itoa(size))
+
+	p.c.Header(ConstructHeader(p.opts.PageText), strconv.Itoa(page))
+	p.c.Header(ConstructHeader(p.opts.SizeText), strconv.Itoa(size))
 }
 
 func (p *paginator) Next() {
 	p.c.Next()
+}
+
+// ConstructHeader creates a standardized header name with X- prefix and proper casing
+func ConstructHeader(text string) string {
+	if text == "" {
+		return ""
+	}
+	return fmt.Sprintf("X-%s%s", strings.ToUpper(text[:1]), text[1:])
 }


### PR DESCRIPTION
It would be nice to have headers returned with pagination settings so that a client could determine if the next page needs to be requested.  eg. if count of results == limit then get next page ..